### PR TITLE
Allow replace metadata.name and metadata.namespace for single yaml structure manifest

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -76,9 +76,11 @@ policies:
             kind: ""
             metadata:
               # Optional: Only required when there are multiple manifests in the path.
+              # Optional: Replace metadata.name is only allowed for a single YAML structure manifest.
               name: ""
               # Optional: Only required when there are multiple manifests in the path and it's a
               # manifest to a namespaced resource.
+              # Optional: Replace metadata.namespace is only allowed for a single YAML structure manifest.
               namespace: ""
               # An example modification to the manifest
               annotations:

--- a/internal/patches.go
+++ b/internal/patches.go
@@ -20,7 +20,7 @@ type manifestPatcher struct {
 	patches []map[string]interface{}
 }
 
-// validateManifestInfo verifes that the apiVersion, kind, metadata.name fields from a manifest
+// validateManifestInfo verifies that the apiVersion, kind, metadata.name fields from a manifest
 // are set. If at least one is not present, an error is returned based on the input error template
 // which accepts the field name.
 func validateManifestInfo(manifest map[string]interface{}, errTemplate string) error {


### PR DESCRIPTION
Allow replace metadata.name and metadata.namespace for single yaml structure manifest

Signed-off-by: melserngawy <melserng@redhat.com>