### PR TITLE
Fix duplicate names when a YAML file has multiple manifests

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -136,7 +136,7 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]map[string
 	policyTemplates := make([]map[string]map[string]interface{}, 0, policyTemplatesLength)
 	for i, manifestGroup := range manifestGroups {
 		complianceType := policyConf.Manifests[i].ComplianceType
-		for j, manifest := range manifestGroup {
+		for _, manifest := range manifestGroup {
 			objTemplate := map[string]interface{}{
 				"complianceType":   complianceType,
 				"objectDefinition": manifest,
@@ -148,7 +148,7 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]map[string
 				// casting each objTemplate with manifest to objectTemplates type
 				// build policyTemplate for each objectTemplates
 				policyTemplate := buildPolicyTemplate(
-					policyConf, i+j+1, &[]map[string]interface{}{objTemplate},
+					policyConf, len(policyTemplates)+1, &[]map[string]interface{}{objTemplate},
 				)
 				setNamespaceSelector(policyConf, policyTemplate)
 				policyTemplates = append(policyTemplates, *policyTemplate)

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -126,9 +126,65 @@ data:
 		}
 		assertEqual(t, kind2, "ConfigMap")
 	}
+}
+
+func TestGetPolicyTemplateNoConsolidate(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	manifestFiles := []types.Manifest{}
+	for i, enemy := range []string{"goldfish", "potato"} {
+		manifestPath := path.Join(tmpDir, fmt.Sprintf("configmap%d.yaml", i))
+		manifestYAML := fmt.Sprintf(
+			`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  game.properties: enemies=%s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap2
+data:
+  game.properties: enemies=%s
+`,
+			enemy,
+			enemy,
+		)
+		err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+		if err != nil {
+			t.Fatalf("Failed to write %s", manifestPath)
+		}
+
+		// The applyDefaults method would normally fill in ComplianceType on each manifest entry.
+		manifestFiles = append(
+			manifestFiles, types.Manifest{ComplianceType: "musthave", Path: manifestPath},
+		)
+	}
+
+	// Write a bogus file to ensure it is not picked up when creating the policy
+	// template
+	bogusFilePath := path.Join(tmpDir, "README.md")
+	err := ioutil.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
+	if err != nil {
+		t.Fatalf("Failed to write %s", bogusFilePath)
+	}
+
+	// Test both passing in individual files and a flat directory
+	tests := []struct {
+		Manifests []types.Manifest
+	}{
+		{Manifests: manifestFiles},
+		// The applyDefaults method would normally fill in ComplianceType on each manifest entry.
+		{
+			Manifests: []types.Manifest{{ComplianceType: "musthave", Path: tmpDir}},
+		},
+	}
 
 	// test ConsolidateManifests = false case
-	// policyTemplates will skip the consolidation and have two policyTemplate
+	// policyTemplates will skip the consolidation and have four policyTemplate
 	// and each policyTemplate has only one objTemplate
 	for _, test := range tests {
 		policyConf := types.PolicyConfig{
@@ -144,48 +200,34 @@ data:
 		if err != nil {
 			t.Fatalf("Failed to get the policy templates: %v", err)
 		}
-		assertEqual(t, len(policyTemplates), 2)
-		policyTemplate1 := policyTemplates[0]
-		objdef1 := policyTemplate1["objectDefinition"]
-		assertEqual(t, objdef1["metadata"].(map[string]string)["name"], "policy-app-config")
-		spec1, ok := objdef1["spec"].(map[string]interface{})
-		if !ok {
-			t.Fatal("The spec field is an invalid format")
-		}
-		assertEqual(t, spec1["remediationAction"], "inform")
-		assertEqual(t, spec1["severity"], "low")
-		objTemplates1, ok := spec1["object-templates"].([]map[string]interface{})
-		if !ok {
-			t.Fatal("The object-templates field is an invalid format")
-		}
-		assertEqual(t, len(objTemplates1), 1)
-		assertEqual(t, objTemplates1[0]["complianceType"], test.ExpectedComplianceType)
-		kind1, ok := objTemplates1[0]["objectDefinition"].(map[string]interface{})["kind"]
-		if !ok {
-			t.Fatal("The objectDefinition field is an invalid format")
-		}
-		assertEqual(t, kind1, "ConfigMap")
+		assertEqual(t, len(policyTemplates), 4)
 
-		policyTemplate2 := policyTemplates[1]
-		objdef2 := policyTemplate2["objectDefinition"]
-		assertEqual(t, objdef2["metadata"].(map[string]string)["name"], "policy-app-config2")
-		spec2, ok := objdef2["spec"].(map[string]interface{})
-		if !ok {
-			t.Fatal("The spec field is an invalid format")
+		for i := 0; i < len(policyTemplates); i++ {
+			policyTemplate := policyTemplates[i]
+			objdef := policyTemplate["objectDefinition"]
+			name := "policy-app-config"
+			if i > 0 {
+				name += fmt.Sprintf("%d", i+1)
+			}
+			assertEqual(t, objdef["metadata"].(map[string]string)["name"], name)
+			spec, ok := objdef["spec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("The spec field is an invalid format")
+			}
+			assertEqual(t, spec["remediationAction"], "inform")
+			assertEqual(t, spec["severity"], "low")
+			objTemplates, ok := spec["object-templates"].([]map[string]interface{})
+			if !ok {
+				t.Fatal("The object-templates field is an invalid format")
+			}
+			assertEqual(t, len(objTemplates), 1)
+			assertEqual(t, objTemplates[0]["complianceType"], "musthave")
+			kind1, ok := objTemplates[0]["objectDefinition"].(map[string]interface{})["kind"]
+			if !ok {
+				t.Fatal("The objectDefinition field is an invalid format")
+			}
+			assertEqual(t, kind1, "ConfigMap")
 		}
-		assertEqual(t, spec2["remediationAction"], "inform")
-		assertEqual(t, spec2["severity"], "low")
-		objTemplates2, ok := spec2["object-templates"].([]map[string]interface{})
-		if !ok {
-			t.Fatal("The object-templates field is an invalid format")
-		}
-		assertEqual(t, len(objTemplates2), 1)
-		assertEqual(t, objTemplates2[0]["complianceType"], test.ExpectedComplianceType)
-		kind2, ok := objTemplates2[0]["objectDefinition"].(map[string]interface{})["kind"]
-		if !ok {
-			t.Fatal("The objectDefinition field is an invalid format")
-		}
-		assertEqual(t, kind2, "ConfigMap")
 	}
 }
 


### PR DESCRIPTION
This only occurs with the consolidateManifests=false option.