### PR TITLE
Fix go install and module path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.so
 *.dylib
 **/.DS_Store
-PolicyGenerator
+/PolicyGenerator
 build_output
 
 # Test binary, built with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ clean:
 
 .PHONY: build
 build: layout
-	go build -o $(API_PLUGIN_PATH)/PolicyGenerator cmd/main.go
+	go build -o $(API_PLUGIN_PATH)/ ./cmd/PolicyGenerator
 
 .PHONY: build-binary
 build-binary:
-	go build -o PolicyGenerator cmd/main.go
+	go build ./cmd/PolicyGenerator
 
 .PHONY: build-release
 build-release:
@@ -62,9 +62,9 @@ build-release:
 			exit 1; \
 	fi
 	@mkdir -p build_output
-	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/linux-amd64-PolicyGenerator cmd/main.go
-	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/darwin-amd64-PolicyGenerator cmd/main.go
-	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/windows-amd64-PolicyGenerator.exe cmd/main.go
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/linux-amd64-PolicyGenerator ./cmd/PolicyGenerator
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/darwin-amd64-PolicyGenerator ./cmd/PolicyGenerator
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/windows-amd64-PolicyGenerator.exe ./cmd/PolicyGenerator
 
 .PHONY: generate
 generate:

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -79,7 +79,7 @@ linters-settings:
     check-shadowing: false
   gci:
     sections:
-      - prefix(open-cluster-management.io/ocm-kustomize-generator-plugins)
+      - prefix(github.com/stolostron/policy-generator-plugin)
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0

--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal"
+	"github.com/stolostron/policy-generator-plugin/internal"
 )
 
 var debug = false

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module open-cluster-management.io/ocm-kustomize-generator-plugins
+module github.com/stolostron/policy-generator-plugin
 
 go 1.18
 

--- a/internal/expanders/expanders.go
+++ b/internal/expanders/expanders.go
@@ -2,7 +2,7 @@
 package expanders
 
 import (
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 )
 
 // GetExpanders returns the list of available expanders.

--- a/internal/expanders/gatekeeper.go
+++ b/internal/expanders/gatekeeper.go
@@ -4,8 +4,8 @@ package expanders
 import (
 	"fmt"
 
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type GatekeeperPolicyExpander struct{}

--- a/internal/expanders/gatekeeper_test.go
+++ b/internal/expanders/gatekeeper_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 )
 
 func TestGatekeeperCanHandle(t *testing.T) {

--- a/internal/expanders/kyverno.go
+++ b/internal/expanders/kyverno.go
@@ -4,8 +4,8 @@ package expanders
 import (
 	"fmt"
 
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type KyvernoPolicyExpander struct{}

--- a/internal/expanders/kyverno_test.go
+++ b/internal/expanders/kyverno_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 )
 
 func TestKyvernoCanHandle(t *testing.T) {

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 const (

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 )
 
 func createConfigMap(t *testing.T, tmpDir, filename string) {
@@ -72,9 +72,9 @@ metadata:
 placementBindingDefaults:
   name: my-placement-binding
 policyDefaults:
-  controls: 
+  controls:
     - PR.DS-1 Data-at-rest
-  metadataComplianceType: musthave 
+  metadataComplianceType: musthave
   namespace: my-policies
   namespaceSelector:
     include:

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type testCase struct {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/stolostron/policy-generator-plugin/internal/expanders"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/expanders"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {


### PR DESCRIPTION
It appears this is a fork of github.com/open-cluster-management-io/ocm-kustomize-generator-plugins, however the go module path was never set for this repo. This means that functionality like `go install github.com/stolostron/policy-generator-plugin/cmd/PolicyGenerator@v1.10.0` doesn't work.

This PR fixes this, allowing this functionality to work as expected.