### PR TITLE
Wrap Gatekeeper manifests directly when expander is disabled

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -81,6 +81,8 @@ policyDefaults:
   # Optional. Determines whether to treat the policy as compliant when it is waiting for its dependencies to reach their
   # desired states. Defaults to false.
   ignorePending: false
+  # Deprecated: Set informGatekeeperPolicies to false to use Gatekeeper manifests directly without wrapping in a
+  # ConfigurationPolicy.
   # Optional. When the policy references a Gatekeeper policy manifest, this determines if an additional configuration
   # policy should be generated in order to receive policy violations in Open Cluster Management when the Gatekeeper
   # policy has been violated. This defaults to true.
@@ -281,6 +283,8 @@ policies:
     pruneObjectBehavior: ""
     # Optional. (See policyDefaults.ignorePending for description.)
     ignorePending: false
+    # Deprecated: Set informGatekeeperPolicies to false to use Gatekeeper manifests 
+    # directly without wrapping in a ConfigurationPolicy.
     # Optional. (See policyDefaults.informGatekeeperPolicies for description.)
     informGatekeeperPolicies: true
     # Optional. (See policyDefaults.informKyvernoPolicies for description.)

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -229,6 +229,8 @@ policies:
 
 	expectedNsSelector := types.NamespaceSelector{Exclude: nil, Include: nil}
 
+	assertEqual(t, p.PolicyDefaults.InformGatekeeperPolicies, true)
+	assertEqual(t, p.PolicyDefaults.InformKyvernoPolicies, true)
 	assertReflectEqual(t, p.PolicyDefaults.NamespaceSelector, expectedNsSelector)
 	assertEqual(t, p.PolicyDefaults.Placement.PlacementRulePath, "")
 	assertEqual(t, len(p.PolicyDefaults.Placement.ClusterSelectors), 0)
@@ -257,6 +259,8 @@ policies:
 	assertEqual(t, policy.RemediationAction, "inform")
 	assertEqual(t, policy.Severity, "low")
 	assertReflectEqual(t, policy.Standards, []string{"NIST SP 800-53"})
+	assertEqual(t, policy.InformGatekeeperPolicies, true)
+	assertEqual(t, policy.InformKyvernoPolicies, true)
 }
 
 func TestConfigNoNamespace(t *testing.T) {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -295,9 +295,16 @@ func isPolicyTypeManifest(manifest map[string]interface{}) (bool, error) {
 		return false, errors.New("invalid or not found kind")
 	}
 
-	isPolicy := strings.HasPrefix(apiVersion, "policy.open-cluster-management.io") &&
-		kind != "Policy" &&
-		strings.HasSuffix(kind, "Policy")
+	// Don't allow generation for root Policies
+	isOcmAPI := strings.HasPrefix(apiVersion, "policy.open-cluster-management.io")
+	if isOcmAPI && kind == "Policy" {
+		return false, errors.New("providing a root Policy kind is not supported by the generator; " +
+			"the manifest should be applied to the hub cluster directly")
+	}
+
+	// Identify OCM Policies
+	isPolicy := isOcmAPI && kind != "Policy" && strings.HasSuffix(kind, "Policy")
+
 
 	if isPolicy {
 		// metadata.name is required on policy manifests

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -628,7 +628,8 @@ func TestIsPolicyTypeManifest(t *testing.T) {
 				},
 			},
 			wantVal: false,
-			wantErr: "",
+			wantErr: "providing a root Policy kind is not supported by the generator; " +
+				"the manifest should be applied to the cluster directly",
 		},
 		"valid PlacementRule": {
 			manifest: map[string]interface{}{


### PR DESCRIPTION
When `informGatekeeperPolicies` is set to `false`, wrap Gatekeeper manifests directly in a Policy rather than in a ConfigurationPolicy.

ref: https://issues.redhat.com/browse/ACM-4438

Additionally, I've noticed some cases where a Policy was being wrapped in a Policy by the generator, causing confusion. I added a commit here to throw an error in this case.