### PR TITLE
Fix `ignorePending` when manifests are consolidated

### DIFF
--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -296,6 +296,30 @@ policies:
 			wantFile: "testdata/ordering/ignore-pending-propagation.yaml",
 			wantErr:  "",
 		},
+		"policyDefaults.ignorePending is propagated with consolidated manifests": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  consolidateManifests: true
+  ignorePending: true
+  namespace: my-policies
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+- name: two
+  ignorePending: false
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+`,
+			wantFile: "testdata/ordering/ignore-pending-policy-consolidated.yaml",
+			wantErr:  "",
+		},
 		"policyDefaults.ignorePending can be overridden at policy level": {
 			tmpDir: tmpDir,
 			generator: `
@@ -543,6 +567,30 @@ policies:
   - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
 `,
 			wantFile: "testdata/ordering/default-extradeps-propagated.yaml",
+			wantErr:  "",
+		},
+		"policyDefaults.extraDependencies is propagated with consolidated manifests": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  consolidateManifests: true
+  namespace: my-policies
+  extraDependencies:
+  - name: extrafoo
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+- name: two
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+`,
+			wantFile: "testdata/ordering/default-extradeps-consolidated.yaml",
 			wantErr:  "",
 		},
 		"policy extraDependencies are propagated": {

--- a/internal/testdata/ordering/default-extradeps-consolidated.yaml
+++ b/internal/testdata/ordering/default-extradeps-consolidated.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: one
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        compliance: Compliant
+        kind: Policy
+        name: extrafoo
+        namespace: my-policies
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: one
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: two
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        compliance: Compliant
+        kind: Policy
+        name: extrafoo
+        namespace: my-policies
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: two
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-one
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-two
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-one
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-one
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: one
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-two
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-two
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: two

--- a/internal/testdata/ordering/ignore-pending-policy-consolidated.yaml
+++ b/internal/testdata/ordering/ignore-pending-policy-consolidated.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: one
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: one
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: two
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: two
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-one
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-two
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-one
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-one
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: one
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-two
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-two
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: two

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -241,6 +241,7 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 			objectTemplates,
 			&policyConf.ConfigurationPolicyOptions,
 		)
+		setTemplateOptions(policyTemplate, policyConf.IgnorePending, policyConf.ExtraDependencies)
 		policyTemplates = append(policyTemplates, policyTemplate)
 	}
 


### PR DESCRIPTION
A call to `setTemplateOptions()` was missed, causing consolidated manifests to not have `ignorePending` set properly (and `extraDependencies` is also affected).

ref: https://issues.redhat.com/browse/ACM-6163