### PR TITLE
Add version flag to generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,24 @@ clean:
 ############################################################
 # build section
 ############################################################
+GIT_VERSION := $(shell git describe --dirty 2>/dev/null)
+ifndef GIT_VERSION
+  GIT_BRANCH := $(shell git branch --show-current)
+  ifdef GIT_BRANCH
+    GIT_VERSION := $(GIT_BRANCH)-$(shell git rev-parse --short HEAD)
+  else
+    GIT_VERSION := $(shell git rev-parse --short HEAD)-dev
+  endif
+endif
+GO_LDFLAGS ?= -X 'main.Version=$(GIT_VERSION)'
 
 .PHONY: build
 build: layout
-	go build -o $(API_PLUGIN_PATH)/ ./cmd/PolicyGenerator
+	go build -ldflags="$(GO_LDFLAGS)" -o $(API_PLUGIN_PATH)/ ./cmd/PolicyGenerator
 
 .PHONY: build-binary
 build-binary:
-	go build ./cmd/PolicyGenerator
+	go build -ldflags="$(GO_LDFLAGS)" ./cmd/PolicyGenerator
 
 .PHONY: build-release
 build-release:
@@ -62,9 +72,9 @@ build-release:
 			exit 1; \
 	fi
 	@mkdir -p build_output
-	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/linux-amd64-PolicyGenerator ./cmd/PolicyGenerator
-	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/darwin-amd64-PolicyGenerator ./cmd/PolicyGenerator
-	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/windows-amd64-PolicyGenerator.exe ./cmd/PolicyGenerator
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -ldflags="$(GO_LDFLAGS)" -o build_output/linux-amd64-PolicyGenerator ./cmd/PolicyGenerator
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -ldflags="$(GO_LDFLAGS)" -o build_output/darwin-amd64-PolicyGenerator ./cmd/PolicyGenerator
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -ldflags="$(GO_LDFLAGS)" -o build_output/windows-amd64-PolicyGenerator.exe ./cmd/PolicyGenerator
 
 .PHONY: generate
 generate:

--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -4,17 +4,30 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 	"open-cluster-management.io/policy-generator-plugin/internal"
 )
+
+var Version string
 
 var debug = false
 
 func main() {
 	// Parse command input
 	debugFlag := pflag.Bool("debug", false, "Print the stack trace with error messages")
+	versionFlag := pflag.Bool("version", false, "Print the version of the generator")
 	pflag.Parse()
+
+	if *versionFlag {
+		if Version == "" {
+			Version = "Unversioned binary"
+		}
+		//nolint:forbidigo
+		fmt.Println(strings.TrimSpace(Version))
+		os.Exit(0)
+	}
 
 	debug = *debugFlag
 


### PR DESCRIPTION
Adds a generator version flag with the Git SHA in the output:
```
v1.12.2-ab49eaf2a21d44265784bbd1f8381ec6e8928828
```

Also adds verification that the `VERSION.txt` file was updated so that a release isn't created without the version being updated.

This is my first time adding version information to anything, so if anyone has other ideas/pointers, do share!

ref: https://issues.redhat.com/browse/ACM-5803

Closes https://github.com/open-cluster-management-io/policy-generator-plugin/issues/118