### PR TITLE
Fetch build version if version wasn't set a build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,10 @@ clean:
 # build section
 ############################################################
 # Parse the version using git, with fallbacks as follows:
-# - git describe (i.e. vX.Y.Z-<sha>)
+# - git describe (i.e. vX.Y.Z-<extra_commits>-<sha>)
 # - <branch>-<sha>
 # - <sha>-dev
+# - Go BuildInfo version
 # - Unversioned binary
 GIT_VERSION := $(shell git describe --dirty 2>/dev/null)
 ifndef GIT_VERSION

--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	runtimeDebug "runtime/debug"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -22,7 +23,14 @@ func main() {
 
 	if *versionFlag {
 		if Version == "" {
-			Version = "Unversioned binary"
+			// Gather the version from the build info
+			if info, ok := runtimeDebug.ReadBuildInfo(); ok {
+				Version = info.Main.Version
+			}
+
+			if Version == "" {
+				Version = "Unversioned binary"
+			}
 		}
 		//nolint:forbidigo
 		fmt.Println(strings.TrimSpace(Version))


### PR DESCRIPTION
Using `go install` resulted in `Unversioned binary`, which didn't seem ideal. This allows us to set the version a build time (which is preferred for our ACM use cases) but also falls back to the Go determined module version when using `go install`, which is also a nice fallback. Here I tagged this branch and it retrieves the version as:
```
$ PolicyGenerator --version
v0.0.0-20230719194345-c518eac8081d
```

Followup to:
- #120
- #121

ref: https://issues.redhat.com/browse/ACM-5803