### PR TITLE
Fetch annotated tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+        # Ref: https://github.com/actions/checkout/issues/290
+      - name: Fetch annotated tag
+        run: |
+          git fetch origin ${{ github.ref }}:${{ github.ref }} --tags --force
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,7 @@ build-binary:
 
 .PHONY: build-release
 build-release:
-	@if [[ $(shell git status --porcelain | wc -l) -gt 0 ]]; \
-		then \
+	@if [ $(shell git status --porcelain | wc -l) -gt 0 ]; then \
 			echo "There are local modifications in the repo" > /dev/stderr; \
 			exit 1; \
 	fi

--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -28,7 +28,7 @@ func main() {
 				Version = info.Main.Version
 			}
 
-			if Version == "" {
+			if Version == "" || Version == "(devel)" {
 				Version = "Unversioned binary"
 			}
 		}


### PR DESCRIPTION
`actions/checkout` creates a lightweight tag, so we need to force a fetch to retrieve the annotated one.

Followup to:
- #122 
- #121 
- #120 

ref: https://issues.redhat.com/browse/ACM-5803