### PR TITLE
Set the severity annotation for non-OCM policies

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -36,6 +36,7 @@ const (
 	maxObjectNameLength        = 63
 	dnsReference               = "https://kubernetes.io/docs/concepts/overview/working-with-objects/names/" +
 		"#dns-subdomain-names"
+	severityAnnotation = "policy.open-cluster-management.io/severity"
 )
 
 // Plugin is used to store the PolicyGenerator configuration and the methods to generate the

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -1183,6 +1183,7 @@ metadata:
 
 	p.PolicyDefaults.Namespace = "gatekeeper-policies"
 	p.PolicyDefaults.InformGatekeeperPolicies = false
+	p.PolicyDefaults.Severity = "critical"
 	policyConf := types.PolicyConfig{
 		Name: "policy-gatekeeper",
 		Manifests: []types.Manifest{
@@ -1220,6 +1221,8 @@ spec:
             apiVersion: templates.gatekeeper.sh/v1
             kind: ConstraintTemplate
             metadata:
+                annotations:
+                    policy.open-cluster-management.io/severity: critical
                 name: myconstrainingtemplate
 `
 	expected = strings.TrimPrefix(expected, "\n")
@@ -1283,6 +1286,8 @@ spec:
             apiVersion: constraints.gatekeeper.sh/v1
             kind: MyConstrainingTemplate
             metadata:
+                annotations:
+                    policy.open-cluster-management.io/severity: low
                 name: thisthingimconstraining
 `
 	expected = strings.TrimPrefix(expected, "\n")

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -190,6 +190,17 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 				// Only set dependency options if it's an OCM policy
 				if isOcmPolicy {
 					setTemplateOptions(policyTemplate, ignorePending, extraDeps)
+				} else {
+					policyTemplateUnstructured := unstructured.Unstructured{Object: manifest}
+
+					annotations := policyTemplateUnstructured.GetAnnotations()
+					if annotations == nil {
+						annotations = make(map[string]string, 1)
+					}
+
+					annotations[severityAnnotation] = policyConf.Severity
+
+					policyTemplateUnstructured.SetAnnotations(annotations)
 				}
 
 				policyTemplates = append(policyTemplates, policyTemplate)

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -768,6 +768,8 @@ func TestIsPolicyTypeManifest(t *testing.T) {
 			gotIsPolicy, gotIsOcmPolicy, gotErr := isPolicyTypeManifest(test.manifest, test.informGatekeeperPolicies)
 			if gotErr != nil {
 				assertEqual(t, gotErr.Error(), test.wantErr)
+			} else if test.wantErr != "" {
+				t.Fatalf("expected the error `%s` but got none", test.wantErr)
 			}
 			assertEqual(t, gotIsPolicy, test.wantIsPolicy)
 			assertEqual(t, gotIsOcmPolicy, test.wantIsOcmPolicy)


### PR DESCRIPTION
For policy-templates entries that are not OCM policies, it is supported to set the `policy.open-cluster-management.io/severity` annotation for other tooling to determine the severity of a noncompliant event. This adds that automatically.

Relates:
https://issues.redhat.com/browse/ACM-6860