### PR TITLE
Fix setting manifest configurations

### DIFF
--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -667,6 +667,33 @@ policies:
 			wantFile: "testdata/ordering/manifest-extradeps-configpolicy.yaml",
 			wantErr:  "",
 		},
+		"manifest extraDependencies are handled with ConfigurationPolicy manifests when defaults are set": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  namespace: my-policies
+  placement:
+    clusterSelector:
+      matchExpressions: []
+  extraDependencies:
+  - kind: IamPolicy
+    name: manifestextra
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configpolicy.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+- name: two
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+`,
+			wantFile: "testdata/ordering/manifest-extradeps-configpolicy-defaults.yaml",
+			wantErr:  "",
+		},
 		"extraDependencies defaults can be overwritten": {
 			tmpDir: tmpDir,
 			generator: `

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -716,7 +716,7 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 				manifest.PruneObjectBehavior = policy.PruneObjectBehavior
 			}
 
-			if manifest.Severity == "" && manifest.Severity != "" {
+			if manifest.Severity == "" && policy.Severity != "" {
 				manifest.Severity = policy.Severity
 			}
 

--- a/internal/testdata/ordering/manifest-extradeps-configpolicy-defaults.yaml
+++ b/internal/testdata/ordering/manifest-extradeps-configpolicy-defaults.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: one
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        compliance: Compliant
+        kind: IamPolicy
+        name: manifestextra
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: configpolicy-my-configmap
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        compliance: Compliant
+        kind: IamPolicy
+        name: manifestextra
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: one
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: two
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        compliance: Compliant
+        kind: IamPolicy
+        name: manifestextra
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: two
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-one
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-two
+  namespace: my-policies
+spec:
+  clusterSelector:
+    matchExpressions: []
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-one
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-one
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: one
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-two
+  namespace: my-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-two
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: two


### PR DESCRIPTION
- Fix severity set at the manifest level
- Fix setting manifest overrides correctly
  -  _Since the manifest configuration wasn't being set when consolidateManifests was true, it wasn't being propagated to things like expanded policies and policy template manifests provided directly. This fixes it to set manifest configurations and then compare manifest and policy configurations to make sure they match when consolidateManifests is true._

ref: https://issues.redhat.com/browse/ACM-9131