### PR TITLE
Allow setting policy open-cluster-management.io/description annoation

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -49,6 +49,8 @@ policyDefaults:
       kind: "Policy"
       # Optional. The APIVersion of the object. Defaults to "policy.open-cluster-management.io/v1"
       apiVersion: "policy.open-cluster-management.io/v1"
+  # Optional. The description of the policy to create.
+  description: ""
   # Optional. Determines whether the policy is enabled or disabled. A disabled policy will not be propagated to any
   # managed clusters and will show no status as a result.
   disabled: false
@@ -272,6 +274,8 @@ policies:
     # Optional. (See policyDefaults.dependencies for description.)
     # Cannot be specified when policyDefaults.orderPolicies is set to true.
     dependencies: []
+    # Optional. (See policyDefaults.description for description.)
+    description: ""
     # Optional. (See policyDefaults.disabled for description.)
     disabled: false
     # Optional. (See policyDefaults.evaluationInterval for description.)

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -550,6 +550,10 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			policy.Controls = p.PolicyDefaults.Controls
 		}
 
+		if policy.Description == "" {
+			policy.Description = p.PolicyDefaults.Description
+		}
+
 		if policy.ComplianceType == "" {
 			policy.ComplianceType = p.PolicyDefaults.ComplianceType
 		}
@@ -1305,6 +1309,7 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 	policyConf.PolicyAnnotations["policy.open-cluster-management.io/standards"] = strings.Join(
 		policyConf.Standards, ",",
 	)
+	policyConf.PolicyAnnotations["policy.open-cluster-management.io/description"] = policyConf.Description
 
 	spec := map[string]interface{}{
 		"disabled":         policyConf.Disabled,

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -92,6 +92,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -127,6 +128,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config2
     namespace: my-policies
@@ -341,6 +343,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -432,6 +435,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -510,6 +514,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -602,6 +607,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -693,6 +699,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -724,6 +731,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config2
     namespace: my-policies
@@ -887,6 +895,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -980,6 +989,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
         test-default-annotation: default
     name: policy-app-config
@@ -1028,6 +1038,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -1075,6 +1086,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
         test-wave-annotation: "100"
     name: policy-app-config
@@ -1143,6 +1155,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: AC Access Control
         policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-limitclusteradmin
     namespace: Iam-policies
@@ -1218,6 +1231,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-gatekeeper
     namespace: gatekeeper-policies
@@ -1283,6 +1297,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-gatekeeper
     namespace: gatekeeper-policies
@@ -1352,6 +1367,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: AC Access Control
         policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-limitclusteradmin
     namespace: Iam-policies
@@ -1425,6 +1441,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -2425,6 +2442,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -2552,6 +2570,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -2674,6 +2693,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies
@@ -2776,6 +2796,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: policy-app-config
     namespace: my-policies

--- a/internal/testdata/ordering/default-deps-propagated.yaml
+++ b/internal/testdata/ordering/default-deps-propagated.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -42,6 +43,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/default-extradeps-consolidated.yaml
+++ b/internal/testdata/ordering/default-extradeps-consolidated.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -50,6 +51,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/default-extradeps-override.yaml
+++ b/internal/testdata/ordering/default-extradeps-override.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -65,6 +66,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/default-extradeps-propagated.yaml
+++ b/internal/testdata/ordering/default-extradeps-propagated.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -65,6 +66,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/dependency-details-config.yaml
+++ b/internal/testdata/ordering/dependency-details-config.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies

--- a/internal/testdata/ordering/extradeps-overrides.yaml
+++ b/internal/testdata/ordering/extradeps-overrides.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies

--- a/internal/testdata/ordering/ignore-pending-manifest-override.yaml
+++ b/internal/testdata/ordering/ignore-pending-manifest-override.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -54,6 +55,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/ignore-pending-policy-consolidated.yaml
+++ b/internal/testdata/ordering/ignore-pending-policy-consolidated.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -45,6 +46,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/ignore-pending-policy-override.yaml
+++ b/internal/testdata/ordering/ignore-pending-policy-override.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -55,6 +56,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/ignore-pending-propagation.yaml
+++ b/internal/testdata/ordering/ignore-pending-propagation.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -55,6 +56,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/manifest-extradeps-configpolicy-defaults.yaml
+++ b/internal/testdata/ordering/manifest-extradeps-configpolicy-defaults.yaml
@@ -6,6 +6,7 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
     policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/description: ""
   name: one
   namespace: my-policies
 spec:
@@ -64,6 +65,7 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
     policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/description: ""
   name: two
   namespace: my-policies
 spec:

--- a/internal/testdata/ordering/manifest-extradeps-configpolicy.yaml
+++ b/internal/testdata/ordering/manifest-extradeps-configpolicy.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -58,6 +59,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/manifest-extradeps.yaml
+++ b/internal/testdata/ordering/manifest-extradeps.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -59,6 +60,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/one-ordered-policy.yaml
+++ b/internal/testdata/ordering/one-ordered-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies

--- a/internal/testdata/ordering/override-dependencies.yaml
+++ b/internal/testdata/ordering/override-dependencies.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -42,6 +43,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/policy-extradeps.yaml
+++ b/internal/testdata/ordering/policy-extradeps.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -65,6 +66,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/testdata/ordering/policy-level-dependencies.yaml
+++ b/internal/testdata/ordering/policy-level-dependencies.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies

--- a/internal/testdata/ordering/three-ordered-manifests.yaml
+++ b/internal/testdata/ordering/three-ordered-manifests.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies

--- a/internal/testdata/ordering/two-ordered-policies.yaml
+++ b/internal/testdata/ordering/two-ordered-policies.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: one
   namespace: my-policies
@@ -36,6 +37,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
     policy.open-cluster-management.io/standards: NIST SP 800-53
   name: two
   namespace: my-policies

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,6 +12,7 @@ type PolicyOptions struct {
 	Controls                       []string           `json:"controls,omitempty" yaml:"controls,omitempty"`
 	CopyPolicyMetadata             bool               `json:"copyPolicyMetadata,omitempty" yaml:"copyPolicyMetadata,omitempty"`
 	Dependencies                   []PolicyDependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Description                    string             `json:"description,omitempty" yaml:"description,omitempty"`
 	ExtraDependencies              []PolicyDependency `json:"extraDependencies,omitempty" yaml:"extraDependencies,omitempty"`
 	Placement                      PlacementConfig    `json:"placement,omitempty" yaml:"placement,omitempty"`
 	Standards                      []string           `json:"standards,omitempty" yaml:"standards,omitempty"`


### PR DESCRIPTION
Adds description field to PolicyOptions.  And sets the default value if not defined in the PolicyGenerator.

https://issues.redhat.com/browse/ACM-9080