### PR TITLE
Fix PolicyGenerator setting InformOnly on root policy

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -598,5 +598,10 @@ func getRootRemediationAction(policyTemplates []map[string]interface{}) string {
 		}
 	}
 
+	// "InformOnly" should only apply to ConfigurationPolicies
+	if strings.EqualFold(action, "informonly") {
+		action = "inform"
+	}
+
 	return action
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1627,4 +1627,12 @@ func TestGetRootRemediationAction(t *testing.T) {
 	objDef["spec"].(map[string]interface{})["remediationAction"] = "enforce"
 	expected = getRootRemediationAction(policyTemplates)
 	assertEqual(t, "enforce", expected)
+
+	objDef["spec"].(map[string]interface{})["remediationAction"] = "InformOnly"
+	expected = getRootRemediationAction(policyTemplates)
+	assertEqual(t, "inform", expected)
+
+	objDef["spec"].(map[string]interface{})["remediationAction"] = "iNfOrMoNlY"
+	expected = getRootRemediationAction(policyTemplates)
+	assertEqual(t, "inform", expected)
 }


### PR DESCRIPTION
When all ConfigurationPolicies have `RemediationAction` `InformOnly`, the root Policy is also set to have `RemediationAction` `InformOnly`. However, `InformOnly` is not valid on a Policy, and was thus modified to be set to `inform` in this case.