### PR TITLE
Add support for object-templates-raw

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -216,7 +216,10 @@ policies:
       #   1) Non-root policy type manifests such as IamPolicy, CertificatePolicy, and ConfigurationPolicy that have a
       #      "Policy" suffix. These are not modified except for patches and are directly added as a Policy's
       #      policy-templates entry.
-      #   2) For everything else, ConfigurationPolicy objects are generated to wrap these manifests. The resulting
+      #   2) Manifests containing only an `object-templates-raw` key. The corresponding value will be used directly in
+      #      a generated ConfigurationPolicy without modification, which will then be added as a Policy's 
+      #      policy-templates entry.
+      #   3) For everything else, ConfigurationPolicy objects are generated to wrap these manifests. The resulting
       #      ConfigurationPolicy is added as a Policy's policy-templates entry.
       - path: ""
         # Optional. (See policyDefaults.complianceType for description.)

--- a/examples/input-object-templates-raw/object-templates-raw.yaml
+++ b/examples/input-object-templates-raw/object-templates-raw.yaml
@@ -1,0 +1,13 @@
+  object-templates-raw: |
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: game-config-aliens
+          namespace: default
+        data:
+          game.properties: |
+            enemies=aliens
+          ui.properties: |
+            color.good=purple

--- a/examples/policyGenerator.yaml
+++ b/examples/policyGenerator.yaml
@@ -53,6 +53,11 @@ policies:
     - path: input-kyverno/
   policySets:
     - policyset-kyverno
+- name: policy-object-templates-raw
+  disabled: true
+  manifests:
+    - path: input-object-templates-raw/
+  remediationAction: enforce
 - name: policy-require-ns-labels
   manifests:
     - path: input-gatekeeper/

--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -271,6 +271,7 @@ func TestIgnorePending(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
+	createObjectTemplatesRawManifest(t, tmpDir, "object-templates-raw.yaml")
 
 	tests := map[string]genOutTest{
 		"policyDefaults.ignorePending is propagated to all manifests": {
@@ -366,6 +367,30 @@ policies:
   - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
 `,
 			wantFile: "testdata/ordering/ignore-pending-manifest-override.yaml",
+			wantErr:  "",
+		},
+		"policyDefaults.ignorePending is propagated with object-templates-raw": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  consolidateManifests: false
+  ignorePending: true
+  namespace: my-policies
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+- name: two
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+`,
+			wantFile: "testdata/ordering/ignore-pending-object-templates-raw.yaml",
 			wantErr:  "",
 		},
 	}
@@ -544,6 +569,7 @@ func TestExtraDependencies(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	createConfigPolicyManifest(t, tmpDir, "configpolicy.yaml")
+	createObjectTemplatesRawManifest(t, tmpDir, "object-templates-raw.yaml")
 
 	tests := map[string]genOutTest{
 		"policyDefaults.extraDependencies are propagated to all manifests": {
@@ -744,6 +770,31 @@ policies:
   - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
 `,
 			wantFile: "testdata/ordering/extradeps-overrides.yaml",
+			wantErr:  "",
+		},
+		"policyDefaults.extraDependencies are propagated with object-templates-raw": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  consolidateManifests: false
+  namespace: my-policies
+  extraDependencies:
+  - name: extrafoo
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+- name: two
+  manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+`,
+			wantFile: "testdata/ordering/default-extradeps-object-templates-raw.yaml",
 			wantErr:  "",
 		},
 	}

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -83,6 +83,29 @@ spec:
 	}
 }
 
+func createObjectTemplatesRawManifest(t *testing.T, tmpDir, filename string) {
+	t.Helper()
+
+	manifestsPath := path.Join(tmpDir, filename)
+	yamlContent := `
+object-templates-raw: |-
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: example
+        namespace: default
+      data:
+        extraData: data
+`
+
+	err := os.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
+	if err != nil {
+		t.Fatalf("Failed to write %s", manifestsPath)
+	}
+}
+
 func TestConfig(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -1364,6 +1364,73 @@ spec:
 	assertEqual(t, output, expected)
 }
 
+func TestCreatePolicyFromObjectTemplatesRawManifest(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createObjectTemplatesRawManifest(t, tmpDir, "objectTemplatesRawPluginTest.yaml")
+
+	p := Plugin{}
+	p.PolicyDefaults.Namespace = "my-policies"
+	policyConf := types.PolicyConfig{
+		PolicyOptions: types.PolicyOptions{
+			Categories: []string{"AC Access Control"},
+			Controls:   []string{"AC-3 Access Enforcement"},
+			Standards:  []string{"NIST SP 800-53"},
+		},
+		Name: "policy-app-config",
+		Manifests: []types.Manifest{
+			{Path: path.Join(tmpDir, "objectTemplatesRawPluginTest.yaml")},
+		},
+	}
+	p.Policies = append(p.Policies, policyConf)
+	p.applyDefaults(map[string]interface{}{})
+
+	err := p.createPolicy(&p.Policies[0])
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	output := p.outputBuffer.String()
+
+	expected := `
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: AC Access Control
+        policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: policy-app-config
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: policy-app-config
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+`
+	expected = strings.TrimPrefix(expected, "\n")
+	assertEqual(t, output, expected)
+}
+
 func TestCreatePolicyWithGkConstraintTemplate(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -3228,6 +3295,7 @@ func TestGenerateEvaluationInterval(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
+	createObjectTemplatesRawManifest(t, tmpDir, "object-templates-raw.yaml")
 
 	p := Plugin{}
 	var err error
@@ -3289,7 +3357,14 @@ func TestGenerateEvaluationInterval(t *testing.T) {
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
-	p.Policies = append(p.Policies, policyConf, policyConf2, policyConf3)
+	// Test that the policy defaults get inherited with object-templates-raw.
+	policyConf4 := types.PolicyConfig{
+		Name: "policy-app-config4",
+		Manifests: []types.Manifest{
+			{Path: path.Join(tmpDir, "object-templates-raw.yaml")},
+		},
+	}
+	p.Policies = append(p.Policies, policyConf, policyConf2, policyConf3, policyConf4)
 	p.applyDefaults(
 		map[string]interface{}{
 			"policies": []interface{}{
@@ -3331,7 +3406,7 @@ func TestGenerateEvaluationInterval(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	assertEqual(t, len(generatedManifests), 9)
+	assertEqual(t, len(generatedManifests), 12)
 
 	for _, manifest := range generatedManifests {
 		kind, _ := manifest["kind"].(string)
@@ -3367,6 +3442,11 @@ func TestGenerateEvaluationInterval(t *testing.T) {
 			assertEqual(t, len(policyTemplates), 1)
 			evaluationInterval := getYAMLEvaluationInterval(t, policyTemplates[0], true)
 			assertEqual(t, len(evaluationInterval), 0)
+		} else if name == "policy-app-config4" {
+			assertEqual(t, len(policyTemplates), 1)
+			evaluationInterval := getYAMLEvaluationInterval(t, policyTemplates[0], false)
+			assertEqual(t, evaluationInterval["compliant"], "never")
+			assertEqual(t, evaluationInterval["noncompliant"], "15s")
 		}
 	}
 }

--- a/internal/testdata/ordering/default-extradeps-object-templates-raw.yaml
+++ b/internal/testdata/ordering/default-extradeps-object-templates-raw.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: one
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: extrafoo
+              namespace: my-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: extrafoo
+              namespace: my-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: two
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: extrafoo
+              namespace: my-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: two
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: extrafoo
+              namespace: my-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: two2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+    name: placement-one
+    namespace: my-policies
+spec:
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+    name: placement-two
+    namespace: my-policies
+spec:
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-one
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: placement-one
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: one
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-two
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: placement-two
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: two

--- a/internal/testdata/ordering/ignore-pending-object-templates-raw.yaml
+++ b/internal/testdata/ordering/ignore-pending-object-templates-raw.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: one
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: one
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: one2
+        spec:
+          object-templates-raw: |-
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ConfigMap
+                  metadata:
+                    name: example
+                    namespace: default
+                  data:
+                    extraData: data
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: two
+  namespace: my-policies
+spec:
+  disabled: false
+  policy-templates:
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: two
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  game.properties: enemies=potato
+                kind: ConfigMap
+                metadata:
+                  name: my-configmap
+          remediationAction: inform
+          severity: low
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: two2
+        spec:
+          object-templates-raw: |-
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ConfigMap
+                  metadata:
+                    name: example
+                    namespace: default
+                  data:
+                    extraData: data
+          remediationAction: inform
+          severity: low
+  remediationAction: inform
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-one
+  namespace: my-policies
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+  tolerations:
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-two
+  namespace: my-policies
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions: []
+  tolerations:
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-one
+  namespace: my-policies
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: placement-one
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: one
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-two
+  namespace: my-policies
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: placement-two
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: two


### PR DESCRIPTION
Adds support for manifest files with only object-templates-raw field, which gets put into a ConfigurationPolicy.

Ref: https://issues.redhat.com/browse/ACM-10565