### PR TITLE
Add support for disabling load restrictions for executing kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ make build
    ```
 
   **NOTE:** To enable Helm processing when passing a Kustomize directory into the generator, set
-  the environment variable `POLICY_GEN_ENABLE_HELM` to `"true"`.
+  the environment variable `POLICY_GEN_ENABLE_HELM` to `"true"`. If the Helm directory is outside of the Kustomize path,
+  you may set the environment variable `POLICY_GEN_DISABLE_LOAD_RESTRICTORS` to `"true"`.
 
 ### As a standalone binary
 
@@ -125,7 +126,8 @@ cd examples
 **NOTE:** 
 - To print the trace in the case of an error, you can add the `--debug` flag to the arguments.
 - To enable Helm processing when passing a Kustomize directory into the generator, set
-  the environment variable `POLICY_GEN_ENABLE_HELM` to `"true"`.
+  the environment variable `POLICY_GEN_ENABLE_HELM` to `"true"`. If the Helm directory is outside of the Kustomize path,
+  you may set the environment variable `POLICY_GEN_DISABLE_LOAD_RESTRICTORS` to `"true"`.
 
 ## Additional Policy Generator references
 

--- a/internal/testdata/helm/Chart.yaml
+++ b/internal/testdata/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm
+description: A Helm chart for testing the Policy Generator
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/internal/testdata/helm/index.yaml
+++ b/internal/testdata/helm/index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  helm:
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2024-02-08T15:55:49.744997-05:00"
+    description: A Helm chart for testing the Policy Generator
+    digest: cd85f8293612983b084f0fb77517c18d99e8d5d49442331d044e50187d577ced
+    name: helm
+    type: application
+    urls:
+    - https://github.com/stolostron/grc-e2e-policy-generator-test/raw/main/helm/helm-0.1.0.tgz
+    version: 0.1.0
+generated: "2024-02-08T15:55:49.744539-05:00"

--- a/internal/testdata/helm/templates/_helpers.tpl
+++ b/internal/testdata/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm.labels" -}}
+helm.sh/chart: {{ include "helm.chart" . }}
+{{ include "helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/internal/testdata/helm/templates/serviceaccount.yaml
+++ b/internal/testdata/helm/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}

--- a/internal/testdata/helm/values.yaml
+++ b/internal/testdata/helm/values.yaml
@@ -1,0 +1,1 @@
+not: used

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -14,6 +14,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/krusty"
+	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 
 	"open-cluster-management.io/policy-generator-plugin/internal/expanders"
@@ -394,6 +395,10 @@ func processKustomizeDir(path string) ([]map[string]interface{}, error) {
 	if os.Getenv("POLICY_GEN_ENABLE_HELM") == "true" {
 		kustomizeOpts.PluginConfig.HelmConfig.Enabled = true
 		kustomizeOpts.PluginConfig.HelmConfig.Command = "helm"
+	}
+
+	if os.Getenv("POLICY_GEN_DISABLE_LOAD_RESTRICTORS") == "true" {
+		kustomizeOpts.LoadRestrictions = kustomizetypes.LoadRestrictionsNone
 	}
 
 	k := krusty.MakeKustomizer(kustomizeOpts)


### PR DESCRIPTION
The user may set POLICY_GEN_DISABLE_LOAD_RESTRICTORS=true to disable the Kustomize load restrictions when the manifest is a Kustomize directory. This is off by default.