### PR TITLE
Add new field gatekeeperEnforcementAction to override enforcementAction

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -199,7 +199,10 @@ policyDefaults:
   # Optional. Labels that the policy will include under its metadata.labels. It will be applied for all
   # policies unless specified in the policy.
   policyLabels: {}
-
+  # Optional. Overrides the spec.enforcementAction field of a Gatekeeper constraint. 
+  # This only applies to Gatekeeper constraints and is ignored by other manifests. 
+  # If not set, the spec.enforcementAction field is not changed.
+  gatekeeperEnforcementAction: "deny"
 # Optional. Defaults for policy set generation. Any default value listed here can be overridden under an entry in the
 # policySets array.
 policySetDefaults:
@@ -260,6 +263,8 @@ policies:
         # Optional. (See policyDefaults.severity for description.)
         # Cannot be specified when policyDefaults.consolidateManifests is set to true.
         severity: "low"
+        # Optional. (See policyDefaults.gatekeeperEnforcementAction for description.)
+        gatekeeperEnforcementAction: "warn"
         # (Note: a path to a directory containing a Kustomize manifest is a supported alternative.) Optional. A
         # Kustomize patch to apply to the manifest(s) at the path. If there are multiple manifests, the patch requires
         # the apiVersion, kind, metadata.name, and metadata.namespace (if applicable) fields to be set so Kustomize can
@@ -351,6 +356,8 @@ policies:
     policyAnnotations: {}
     # Optional. (See policyDefaults.policyLabels for description.)
     policyLabels: {}
+    # Optional. (See policyDefaults.gatekeeperEnforcementAction for description.)
+    gatekeeperEnforcementAction: "dryrun"
 
 # Optional. The list of policy sets to create. To include a policy in a policy set, use policies[*].policySets or
 # policyDefaults.policySets or policySets.policies.

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -579,6 +579,10 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			policy.MetadataComplianceType = p.PolicyDefaults.MetadataComplianceType
 		}
 
+		if policy.GatekeeperEnforcementAction == "" {
+			policy.GatekeeperEnforcementAction = p.PolicyDefaults.GatekeeperEnforcementAction
+		}
+
 		// Only use the policyDefault evaluationInterval value when it's not explicitly set on the policy.
 		if policy.EvaluationInterval.Compliant == "" {
 			set := isEvaluationIntervalSet(unmarshaledConfig, i, "compliant")
@@ -743,6 +747,10 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 
 			if manifest.RecordDiff == "" {
 				manifest.RecordDiff = policy.RecordDiff
+			}
+
+			if manifest.GatekeeperEnforcementAction == "" {
+				manifest.GatekeeperEnforcementAction = policy.GatekeeperEnforcementAction
 			}
 
 			if isManifestFieldSet(unmarshaledConfig, i, j, "extraDependencies") {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -47,8 +47,13 @@ type ConfigurationPolicyOptions struct {
 	RecreateOption         string             `json:"recreateOption,omitempty" yaml:"recreateOption,omitempty"`
 }
 
+type GatekeeperOptions struct {
+	GatekeeperEnforcementAction string `json:"gatekeeperEnforcementAction,omitempty" yaml:"gatekeeperEnforcementAction,omitempty"`
+}
+
 type Manifest struct {
 	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	GatekeeperOptions          `json:",inline" yaml:",inline"`
 	Patches                    []map[string]interface{} `json:"patches,omitempty" yaml:"patches,omitempty"`
 	Path                       string                   `json:"path,omitempty" yaml:"path,omitempty"`
 	ExtraDependencies          []PolicyDependency       `json:"extraDependencies,omitempty" yaml:"extraDependencies,omitempty"`
@@ -105,6 +110,7 @@ type EvaluationInterval struct {
 type PolicyConfig struct {
 	PolicyOptions              `json:",inline" yaml:",inline"`
 	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	GatekeeperOptions          `json:",inline" yaml:",inline"`
 	Name                       string `json:"name,omitempty" yaml:"name,omitempty"`
 	// This a slice of structs to allow additional configuration related to a manifest such as
 	// accepting patches.
@@ -114,6 +120,7 @@ type PolicyConfig struct {
 type PolicyDefaults struct {
 	PolicyOptions              `json:",inline" yaml:",inline"`
 	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	GatekeeperOptions          `json:",inline" yaml:",inline"`
 	Namespace                  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	OrderPolicies              bool   `json:"orderPolicies,omitempty" yaml:"orderPolicies,omitempty"`
 }


### PR DESCRIPTION
- Add a new field of `gatekeeperEnforcementAction`
- Default value of the field is unset and when unset, don't touch the constraint (existing behavior) 
- If set, then directly set `spec.enforcementAction` in the Gatekeeper constraint 
- Should be settable at the policyDefaults, policy, and manifest levels (i.e. like the `ConfigurationPolicyOptions` struct).
Ref: https://issues.redhat.com/browse/ACM-11076
Signed-off-by: yiraeChristineKim <yikim@redhat.com>