### PR TITLE
Add setting name on ConfigurationPolicy

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -234,6 +234,9 @@ policies:
       #   3) For everything else, ConfigurationPolicy objects are generated to wrap these manifests. The resulting
       #      ConfigurationPolicy is added as a Policy's policy-templates entry.
       - path: ""
+        # Optional. This name is used when ConsolidateManifests is set to false and will serve as the ConfigurationPolicy name.
+        # If multiple manifests are present in the path, an index number will be appended.
+        name: "my-config-name"
         # Optional. (See policyDefaults.complianceType for description.)
         complianceType: "musthave"
         # Optional. (See policyDefaults.metadataComplianceType for description.)

--- a/internal/testdata/ordering/manifest-level-name-raw-consolidate-false.yaml
+++ b/internal/testdata/ordering/manifest-level-name-raw-consolidate-false.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: one
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: tiger
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: tiger2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+    name: placement-one
+    namespace: my-policies
+spec:
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-one
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: placement-one
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: one

--- a/internal/testdata/ordering/manifest-level-name-raw-consolidate-true.yaml
+++ b/internal/testdata/ordering/manifest-level-name-raw-consolidate-true.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: one
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one3
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one4
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+    name: placement-one
+    namespace: my-policies
+spec:
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-one
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: placement-one
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: one

--- a/internal/testdata/ordering/manifest-level-name.yaml
+++ b/internal/testdata/ordering/manifest-level-name.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: one
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one2
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: elephant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: lion
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: elephant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: lion2
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: lion
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: tiger
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: lion
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: tiger2
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: tiger2
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: lion2
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: bird
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: tiger2
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: ConfigurationPolicy
+              name: lion2
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: bird2
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+    name: placement-one
+    namespace: my-policies
+spec:
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-one
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: placement-one
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: one

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -59,6 +59,7 @@ type Manifest struct {
 	ExtraDependencies          []PolicyDependency       `json:"extraDependencies,omitempty" yaml:"extraDependencies,omitempty"`
 	IgnorePending              bool                     `json:"ignorePending,omitempty" yaml:"ignorePending,omitempty"`
 	OpenAPI                    Filepath                 `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	Name                       string                   `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 type Filepath struct {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -177,7 +177,7 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 		ignorePending := policyConf.Manifests[i].IgnorePending
 		extraDeps := policyConf.Manifests[i].ExtraDependencies
 
-		for _, manifest := range manifestGroup {
+		for j, manifest := range manifestGroup {
 			err := setGatekeeperEnforcementAction(manifest,
 				policyConf.Manifests[i].GatekeeperEnforcementAction)
 			if err != nil {
@@ -202,9 +202,10 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 				if found {
 					policyTemplate = buildPolicyTemplate(
 						policyConf,
-						len(policyTemplates)+1,
 						manifest["object-templates-raw"],
 						&policyConf.Manifests[i].ConfigurationPolicyOptions,
+						getConfigurationPolicyName(policyConf, i, len(policyTemplates),
+							j, !policyConf.ConsolidateManifests),
 					)
 				} else {
 					policyTemplate = map[string]interface{}{"objectDefinition": manifest}
@@ -256,9 +257,10 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 				// build policyTemplate for each objectTemplates
 				policyTemplate := buildPolicyTemplate(
 					policyConf,
-					len(policyTemplates)+1,
 					[]map[string]interface{}{objTemplate},
 					&policyConf.Manifests[i].ConfigurationPolicyOptions,
+					getConfigurationPolicyName(policyConf, i, len(policyTemplates),
+						j, !policyConf.ConsolidateManifests),
 				)
 
 				setTemplateOptions(policyTemplate, ignorePending, extraDeps)
@@ -279,9 +281,9 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 	if policyConf.ConsolidateManifests && len(objectTemplates) > 0 {
 		policyTemplate := buildPolicyTemplate(
 			policyConf,
-			1,
 			objectTemplates,
 			&policyConf.ConfigurationPolicyOptions,
+			getConfigurationPolicyName(policyConf, 0, 0, 0, false),
 		)
 		setTemplateOptions(policyTemplate, policyConf.IgnorePending, policyConf.ExtraDependencies)
 		policyTemplates = append(policyTemplates, policyTemplate)
@@ -315,6 +317,32 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 	}
 
 	return policyTemplates, nil
+}
+
+// This function returns configurationPolicyName with Index+1 based on the provided PolicyConfig.
+// When index is 0, it won't attach any number. When useManifestName is true,
+// it returns the policyConf.Manifests[manifestGroupIndex].Name otherwise,
+// It returns policyConf.Name + index
+func getConfigurationPolicyName(policyConf *types.PolicyConfig, manifestGroupIndex, policyNum,
+	manifestIndex int, useManifestName bool,
+) string {
+	// Do not append a number to configName when it is used for the first time.
+	configName := policyConf.Manifests[manifestGroupIndex].Name
+
+	if useManifestName && configName != "" {
+		if manifestIndex > 0 {
+			return fmt.Sprintf("%s%d", configName, manifestIndex+1)
+		}
+
+		return configName
+	}
+
+	configName = policyConf.Name
+	if policyNum > 0 {
+		return fmt.Sprintf("%s%d", configName, policyNum+1)
+	}
+
+	return configName
 }
 
 // setGatekeeperEnforcementAction function override gatekeeper.constraint.enforcementAction
@@ -451,17 +479,10 @@ func processKustomizeDir(path string) ([]map[string]interface{}, error) {
 // one then the configuration policy name will have policyNum appended to it.
 func buildPolicyTemplate(
 	policyConf *types.PolicyConfig,
-	policyNum int,
 	objectTemplates interface{},
 	configPolicyOptionsOverrides *types.ConfigurationPolicyOptions,
+	configPolicyName string,
 ) map[string]interface{} {
-	var name string
-	if policyNum > 1 {
-		name = fmt.Sprintf("%s%d", policyConf.Name, policyNum)
-	} else {
-		name = policyConf.Name
-	}
-
 	policySpec := map[string]interface{}{
 		"remediationAction": policyConf.RemediationAction,
 		"severity":          policyConf.Severity,
@@ -479,7 +500,7 @@ func buildPolicyTemplate(
 			"apiVersion": policyAPIVersion,
 			"kind":       configPolicyKind,
 			"metadata": map[string]interface{}{
-				"name": name,
+				"name": configPolicyName,
 			},
 			"spec": policySpec,
 		},


### PR DESCRIPTION
When creating a policy with multiple manifests and `consolidateManfifest: false` the generated ConfigurationPolicies are names after the Policy with an index appended.

This causes issues when attempting to use extraDependencies such as below.  Adding an additional manifest will change the index causing the existing dependencies to be incorrect.

Allowing setting the name would also make it easier to identify in the UI when reviewing a policy.


Ref: https://issues.redhat.com/browse/ACM-12563