### PR TITLE
Fix: Clean namespaces from Policy types

### DIFF
--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -68,6 +68,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: CertificatePolicy
 metadata:
   name: certpolicy-minduration
+  namespace: test
 spec:
   severity: medium
   namespaceSelector:

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -212,6 +212,9 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{
 
 				// Only set dependency options if it's an OCM policy
 				if isOcmPolicy {
+					// Remove any namespace specified in the OCM policy since that would be invalid
+					unstructured.RemoveNestedField(manifest, "metadata", "namespace")
+
 					setTemplateOptions(policyTemplate, ignorePending, extraDeps)
 				} else {
 					policyTemplateUnstructured := unstructured.Unstructured{Object: manifest}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -922,6 +922,8 @@ func TestGetPolicyTemplateFromPolicyTypeManifest(t *testing.T) {
 		// kind will not be overridden by "ConfigurationPolicy".
 		assertEqual(t, CertObjdef["kind"], "CertificatePolicy")
 		assertEqual(t, CertObjdef["metadata"].(map[string]interface{})["name"], "certpolicy-minduration")
+		// The namespace is removed
+		assertEqual(t, CertObjdef["metadata"].(map[string]interface{})["namespace"], nil)
 
 		CertSpec, ok := CertObjdef["spec"].(map[string]interface{})
 		if !ok {


### PR DESCRIPTION
Fixes when one of our policy types is provided and specifies a namespace (either directly or through an embedded Kustomize namespace transformer).

ref: https://issues.redhat.com/browse/ACM-8839