### PR TITLE
Refactor name setting for complex cases

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -236,6 +236,8 @@ policies:
       - path: ""
         # Optional. This name is used when ConsolidateManifests is set to false and will serve as the ConfigurationPolicy name.
         # If multiple manifests are present in the path, an index number will be appended.
+        # If multiple manifests are present and their names are provided, with `consolidateManifests` set to true,
+        # the name of the first manifest will be used for all manifest paths.
         name: "my-config-name"
         # Optional. (See policyDefaults.complianceType for description.)
         complianceType: "musthave"

--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -293,10 +293,16 @@ metadata:
 policyDefaults:
   orderPolicies: true
   namespace: my-policies
-  consolidateManifests: false
+  consolidateManifests: true
 policies:
 - name: one
   manifests:
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+    name: tiger
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+    name: rabbit
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+    name: bird
   - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
   - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
 `,

--- a/internal/testdata/ordering/manifest-extradeps-configpolicy.yaml
+++ b/internal/testdata/ordering/manifest-extradeps-configpolicy.yaml
@@ -38,7 +38,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: one2
+          name: one
         spec:
           object-templates:
             - complianceType: musthave

--- a/internal/testdata/ordering/manifest-level-name-raw-consolidate-true.yaml
+++ b/internal/testdata/ordering/manifest-level-name-raw-consolidate-true.yaml
@@ -16,6 +16,42 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+                name: bird
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: bird2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
                 name: one
             spec:
                 object-templates-raw: |-
@@ -82,6 +118,47 @@ spec:
                           namespace: default
                         data:
                           extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: tiger
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
                 remediationAction: inform
                 severity: low
     remediationAction: inform


### PR DESCRIPTION
This PR supports the more complex cases of setting names. Especially, `consolidateManifests` is true and the `manifest-path name` is present.
https://issues.redhat.com/browse/ACM-1256