### PR TITLE
Fix the bug where raw is abead of obj-temp 

### DIFF
--- a/internal/ordering_test.go
+++ b/internal/ordering_test.go
@@ -252,12 +252,12 @@ policies:
     remediationAction: inform
     name: bird
     extraDependencies:
-      - name: tiger2
-        kind: ConfigurationPolicy
-        compliance: "Compliant"
-      - name: lion2
-        kind: ConfigurationPolicy
-        compliance: "Compliant"
+    - name: tiger2
+      kind: ConfigurationPolicy
+      compliance: "Compliant"
+    - name: lion2
+      kind: ConfigurationPolicy
+      compliance: "Compliant"
 `,
 			wantFile: "testdata/ordering/manifest-level-name.yaml",
 			wantErr:  "",
@@ -283,7 +283,7 @@ policies:
 			wantFile: "testdata/ordering/manifest-level-name-raw-consolidate-false.yaml",
 			wantErr:  "",
 		},
-		"complicated raw policies with consolidateManifests true": {
+		"consolidateManifests true and objTemplate with raw": {
 			tmpDir: tmpDir,
 			generator: `
 apiVersion: policy.open-cluster-management.io/v1
@@ -297,16 +297,58 @@ policyDefaults:
 policies:
 - name: one
   manifests:
-  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
-    name: tiger
-  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
-    name: rabbit
   - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
     name: bird
-  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
-  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+    name: tiger
 `,
 			wantFile: "testdata/ordering/manifest-level-name-raw-consolidate-true.yaml",
+			wantErr:  "",
+		},
+		"consolidateManifests true and objTemplate with empty name": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  orderPolicies: true
+  namespace: my-policies
+  consolidateManifests: true
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+    name: bird
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+`,
+			wantFile: "testdata/ordering/manifest-level-name-raw-consolidate-true-empty-name.yaml",
+			wantErr:  "",
+		},
+		"consolidateManifests true and objTemplate with name": {
+			tmpDir: tmpDir,
+			generator: `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: test
+policyDefaults:
+  orderPolicies: true
+  namespace: my-policies
+  consolidateManifests: true
+policies:
+- name: one
+  manifests:
+  - path: {{printf "%v/%v" .Dir "object-templates-raw.yaml"}}
+    name: bird
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+  - path: {{printf "%v/%v" .Dir "configmap.yaml"}}
+    name: tiger
+`,
+			wantFile: "testdata/ordering/manifest-level-name-raw-consolidate-true-with-name.yaml",
 			wantErr:  "",
 		},
 	}

--- a/internal/testdata/ordering/manifest-level-name-raw-consolidate-true-empty-name.yaml
+++ b/internal/testdata/ordering/manifest-level-name-raw-consolidate-true-empty-name.yaml
@@ -16,6 +16,42 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+                name: one
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: one2
+            spec:
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: example
+                          namespace: default
+                        data:
+                          extraData: data
+                remediationAction: inform
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
                 name: bird
             spec:
                 object-templates-raw: |-
@@ -52,9 +88,25 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-                name: tiger
+                name: one3
             spec:
                 object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
                     - complianceType: musthave
                       objectDefinition:
                         apiVersion: v1

--- a/internal/testdata/ordering/manifest-level-name-raw-consolidate-true-with-name.yaml
+++ b/internal/testdata/ordering/manifest-level-name-raw-consolidate-true-with-name.yaml
@@ -71,6 +71,22 @@ spec:
                         kind: ConfigMap
                         metadata:
                             name: config-2
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=cabbage
+                        kind: ConfigMap
+                        metadata:
+                            name: config-2
                 remediationAction: inform
                 severity: low
     remediationAction: inform


### PR DESCRIPTION
There is a bug when `raw-template`  manifest is ahead of `obj-template` manifest.
https://issues.redhat.com/browse/ACM-12563