### PR TITLE
Remove `replace` from `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,5 +47,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16 // Replaced so that 'go get -u' works. Remove/bump when upgrading.


### PR DESCRIPTION
Not sure how this even got in here (it was me 🤷‍♂️ ) , but it's breaking `go install` and it seems to work without it.