### PR TITLE
Add `-mod=readonly` to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build-release:
 	fi
 	@for OS in linux darwin windows; do for ARCH in amd64 arm64; do \
 			echo "# Building $${OS}-$${ARCH}-PolicyGenerator"; \
-			GOOS=$${OS} GOARCH=$${ARCH} CGO_ENABLED=0 go build -ldflags="$(GO_LDFLAGS)" -o build_output/$${OS}-$${ARCH}-PolicyGenerator ./cmd/PolicyGenerator; \
+			GOOS=$${OS} GOARCH=$${ARCH} CGO_ENABLED=0 go build -mod=readonly -ldflags="$(GO_LDFLAGS)" -o build_output/$${OS}-$${ARCH}-PolicyGenerator ./cmd/PolicyGenerator; \
 		done; done
 	# Adding .exe extension to Windows binaries
 	@for FILE in $$(ls -1 build_output/windows-* | grep -v ".exe$$"); do \


### PR DESCRIPTION
Required for Konflux (the other option is to add `go mod vendor` somewhere, but I think this ought to suffice)