### PR TITLE
🐛 [Bug]Fix evaluationInterval 'watch' bug

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -1028,7 +1028,9 @@ func (p *Plugin) assertValidConfig() error {
 				p.PolicyDefaults.Namespace, policy.Name)
 		}
 
-		if policy.EvaluationInterval.Compliant != "" && policy.EvaluationInterval.Compliant != "never" {
+		if policy.EvaluationInterval.Compliant != "" &&
+			policy.EvaluationInterval.Compliant != "never" &&
+			policy.EvaluationInterval.Compliant != "watch" {
 			_, err := time.ParseDuration(policy.EvaluationInterval.Compliant)
 			if err != nil {
 				return fmt.Errorf(
@@ -1037,7 +1039,9 @@ func (p *Plugin) assertValidConfig() error {
 			}
 		}
 
-		if policy.EvaluationInterval.NonCompliant != "" && policy.EvaluationInterval.NonCompliant != "never" {
+		if policy.EvaluationInterval.NonCompliant != "" &&
+			policy.EvaluationInterval.NonCompliant != "never" &&
+			policy.EvaluationInterval.Compliant != "watch" {
 			_, err := time.ParseDuration(policy.EvaluationInterval.NonCompliant)
 			if err != nil {
 				return fmt.Errorf(
@@ -1149,7 +1153,8 @@ func (p *Plugin) assertValidConfig() error {
 				}
 			}
 
-			if evalInterval.Compliant != "" && evalInterval.Compliant != "never" {
+			if evalInterval.Compliant != "" && evalInterval.Compliant != "never" &&
+				evalInterval.Compliant != "watch" {
 				_, err := time.ParseDuration(evalInterval.Compliant)
 				if err != nil {
 					return fmt.Errorf(
@@ -1161,7 +1166,8 @@ func (p *Plugin) assertValidConfig() error {
 				}
 			}
 
-			if evalInterval.NonCompliant != "" && evalInterval.NonCompliant != "never" {
+			if evalInterval.NonCompliant != "" && evalInterval.NonCompliant != "never" &&
+				evalInterval.NonCompliant != "watch" {
 				_, err := time.ParseDuration(evalInterval.NonCompliant)
 				if err != nil {
 					return fmt.Errorf(

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -956,7 +956,7 @@ policies:
 	assertEqual(t, err.Error(), expected)
 }
 
-func TestConfigInvalidEvalInterval(t *testing.T) {
+func TestConfigEvalInterval(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
@@ -1025,6 +1025,12 @@ func TestConfigInvalidEvalInterval(t *testing.T) {
 			`the policy policy-app has an invalid policy.evaluationInterval.noncompliant value: time: unknown unit ` +
 				`"w" in duration "1w2d"`,
 		},
+		{
+			`{"compliant": "watch", "noncompliant": "watch"}`,
+			`{"compliant": "watch", "noncompliant": "watch"}`,
+			`{"compliant": "watch", "noncompliant": "watch"}`,
+			``,
+		},
 	}
 
 	for _, test := range tests {
@@ -1056,12 +1062,19 @@ policies:
 				)
 
 				p := Plugin{}
+
 				err := p.Config([]byte(config), tmpDir)
 				if err == nil {
-					t.Fatal("Expected an error but did not get one")
-				}
+					if test.expectedMsg != "" {
+						t.Fatal("Expected an error but did not receive one")
+					}
+				} else {
+					if test.expectedMsg == "" {
+						t.Fatalf("Expected no error but received: %v", err)
+					}
 
-				assertEqual(t, err.Error(), test.expectedMsg)
+					assertEqual(t, err.Error(), test.expectedMsg)
+				}
 			},
 		)
 	}


### PR DESCRIPTION
Policy generator plugin does not allow evaluationInterval to be set to "watch". The policy generator should generate policy successfully with "watch"
 Ref: https://issues.redhat.com/browse/ACM-17774
Signed-off-by: yiraeChristineKim <yikim@redhat.com>