### PR TITLE
Fix cli help flag return code

### DIFF
--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -19,8 +19,16 @@ var debug = false
 func main() {
 	// Parse command input
 	debugFlag := pflag.Bool("debug", false, "Print the stack trace with error messages")
+	helpFlag := pflag.BoolP("help", "h", false, "Print the help message")
 	versionFlag := pflag.Bool("version", false, "Print the version of the generator")
 	pflag.Parse()
+
+	if *helpFlag {
+		//nolint:forbidigo
+		fmt.Println("Usage: PolicyGenerator [flags] <policy-generator-config-file>...")
+		pflag.PrintDefaults()
+		os.Exit(0)
+	}
 
 	if *versionFlag {
 		if Version == "" {


### PR DESCRIPTION
When the help command is not implemented, pflag returns the message `help requested` and an exit code of 2.

This PR returns an exit code of 0 after running the help command.

ref: https://issues.redhat.com/browse/ACM-21054

```
$ make build-binary
$ ./PolicyGenerator -h
Usage: PolicyGenerator [flags] <policy-generator-config-file>...
      --debug     Print the stack trace with error messages
  -h, --help      Print the help message
      --version   Print the version of the generator
$ echo $?
0
$ ./PolicyGenerator --help
Usage: PolicyGenerator [flags] <policy-generator-config-file>...
      --debug     Print the stack trace with error messages
  -h, --help      Print the help message
      --version   Print the version of the generator
$ echo $?
0
```