### PR TITLE
Expand new kyverno policy types

### DIFF
--- a/internal/expanders/kyverno.go
+++ b/internal/expanders/kyverno.go
@@ -10,20 +10,43 @@ import (
 type KyvernoPolicyExpander struct{}
 
 const (
-	kyvernoAPIVersion             = "kyverno.io/v1"
-	kyvernoClusterKind            = "ClusterPolicy"
-	kyvernoPolicyReportAPIVersion = "wgpolicyk8s.io/v1alpha2"
-	kyvernoNamespacedKind         = "Policy"
+	kyvernoAPIVersion                      = "kyverno.io/v1"
+	kyvernoPolicyAPIVersion                = "policies.kyverno.io/v1"
+	kyvernoPolicyReportAPIVersion          = "wgpolicyk8s.io/v1alpha2"
+	kyvernoClusterPolicy                   = "ClusterPolicy"
+	kyvernoNamespacedPolicy                = "Policy"
+	kyvernoValidatingPolicy                = "ValidatingPolicy"
+	kyvernoMutatingPolicy                  = "MutatingPolicy"
+	kyvernoGeneratingPolicy                = "GeneratingPolicy"
+	kyvernoImageValidatingPolicy           = "ImageValidatingPolicy"
+	kyvernoNamespacedValidatingPolicy      = "NamespacedValidatingPolicy"
+	kyvernoNamespacedMutatingPolicy        = "NamespacedMutatingPolicy"
+	kyvernoNamespacedGeneratingPolicy      = "NamespacedGeneratingPolicy"
+	kyvernoNamespacedImageValidatingPolicy = "NamespacedImageValidatingPolicy"
+	clusterPolicyReportKind                = "ClusterPolicyReport"
+	namespacedPolicyReportKind             = "PolicyReport"
 )
+
+// isValidKyvernoKind checks if the apiVersion and kind represent a supported Kyverno policy.
+func isValidKyvernoKind(apiVersion, kind string) bool {
+	switch kind {
+	case kyvernoClusterPolicy, kyvernoNamespacedPolicy:
+		return apiVersion == kyvernoAPIVersion
+	case kyvernoValidatingPolicy, kyvernoMutatingPolicy, kyvernoGeneratingPolicy, kyvernoImageValidatingPolicy,
+		kyvernoNamespacedValidatingPolicy, kyvernoNamespacedMutatingPolicy,
+		kyvernoNamespacedGeneratingPolicy, kyvernoNamespacedImageValidatingPolicy:
+		return apiVersion == kyvernoPolicyAPIVersion
+	default:
+		return false
+	}
+}
 
 // CanHandle determines if the manifest is a Kyverno policy that can be expanded.
 func (k KyvernoPolicyExpander) CanHandle(manifest map[string]interface{}) bool {
-	if a, _, _ := unstructured.NestedString(manifest, "apiVersion"); a != kyvernoAPIVersion {
-		return false
-	}
-
+	apiVersion, _, _ := unstructured.NestedString(manifest, "apiVersion")
 	kind, _, _ := unstructured.NestedString(manifest, "kind")
-	if kind != kyvernoClusterKind && kind != kyvernoNamespacedKind {
+
+	if !isValidKyvernoKind(apiVersion, kind) {
 		return false
 	}
 
@@ -66,7 +89,7 @@ func (k KyvernoPolicyExpander) Expand(
 						"complianceType": "mustnothave",
 						"objectDefinition": map[string]interface{}{
 							"apiVersion": kyvernoPolicyReportAPIVersion,
-							"kind":       kyvernoClusterKind + "Report",
+							"kind":       clusterPolicyReportKind,
 							"results": []map[string]interface{}{
 								{
 									"policy": policyName,
@@ -79,7 +102,7 @@ func (k KyvernoPolicyExpander) Expand(
 						"complianceType": "mustnothave",
 						"objectDefinition": map[string]interface{}{
 							"apiVersion": kyvernoPolicyReportAPIVersion,
-							"kind":       kyvernoNamespacedKind + "Report",
+							"kind":       namespacedPolicyReportKind,
 							"results": []map[string]interface{}{
 								{
 									"policy": policyName,

--- a/internal/expanders/kyverno_test.go
+++ b/internal/expanders/kyverno_test.go
@@ -12,9 +12,21 @@ func TestKyvernoCanHandle(t *testing.T) {
 	t.Parallel()
 
 	k := KyvernoPolicyExpander{}
-	tests := []struct{ kind string }{
-		{kyvernoClusterKind},
-		{kyvernoNamespacedKind},
+
+	tests := []struct {
+		apiVersion string
+		kind       string
+	}{
+		{kyvernoAPIVersion, kyvernoClusterPolicy},
+		{kyvernoAPIVersion, kyvernoNamespacedPolicy},
+		{kyvernoPolicyAPIVersion, "ValidatingPolicy"},
+		{kyvernoPolicyAPIVersion, "MutatingPolicy"},
+		{kyvernoPolicyAPIVersion, "GeneratingPolicy"},
+		{kyvernoPolicyAPIVersion, "ImageValidatingPolicy"},
+		{kyvernoPolicyAPIVersion, "NamespacedValidatingPolicy"},
+		{kyvernoPolicyAPIVersion, "NamespacedMutatingPolicy"},
+		{kyvernoPolicyAPIVersion, "NamespacedGeneratingPolicy"},
+		{kyvernoPolicyAPIVersion, "NamespacedImageValidatingPolicy"},
 	}
 
 	for _, test := range tests {
@@ -24,7 +36,7 @@ func TestKyvernoCanHandle(t *testing.T) {
 				t.Parallel()
 
 				manifest := map[string]interface{}{
-					"apiVersion": kyvernoAPIVersion,
+					"apiVersion": test.apiVersion,
 					"kind":       test.kind,
 					"metadata": map[string]interface{}{
 						"name": "my-awesome-policy",
@@ -41,11 +53,15 @@ func TestKyvernoCanHandleInvalid(t *testing.T) {
 
 	k := KyvernoPolicyExpander{}
 	tests := []struct{ apiVersion, kind, name string }{
-		{"v1", kyvernoClusterKind, "my-awesome-policy"},
-		{"v1", kyvernoNamespacedKind, "my-awesome-policy"},
+		{"v1", kyvernoClusterPolicy, "my-awesome-policy"},
+		{"v1", kyvernoNamespacedPolicy, "my-awesome-policy"},
 		{kyvernoAPIVersion, "ConfigMap", "my-awesome-policy"},
-		{kyvernoAPIVersion, kyvernoClusterKind, ""},
-		{kyvernoAPIVersion, kyvernoNamespacedKind, ""},
+		{kyvernoAPIVersion, kyvernoClusterPolicy, ""},
+		{kyvernoAPIVersion, kyvernoNamespacedPolicy, ""},
+		{kyvernoPolicyAPIVersion, kyvernoClusterPolicy, "my-awesome-policy"},
+		{kyvernoPolicyAPIVersion, kyvernoNamespacedPolicy, "my-awesome-policy"},
+		{"policies.kyverno.io/v2", "ValidatingPolicy", "my-awesome-policy"},
+		{kyvernoPolicyAPIVersion, "ValidatingPolicy", ""},
 	}
 
 	for _, test := range tests {
@@ -87,61 +103,86 @@ func TestKyvernoExpand(t *testing.T) {
 	t.Parallel()
 
 	k := KyvernoPolicyExpander{}
-	manifest := map[string]interface{}{
-		"apiVersion": kyvernoAPIVersion,
-		"kind":       kyvernoClusterKind,
-		"metadata": map[string]interface{}{
-			"name": "my-awesome-policy",
-		},
+
+	tests := []struct {
+		apiVersion string
+		kind       string
+	}{
+		{kyvernoAPIVersion, kyvernoClusterPolicy},
+		{kyvernoAPIVersion, kyvernoNamespacedPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoValidatingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoMutatingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoGeneratingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoImageValidatingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoNamespacedValidatingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoNamespacedMutatingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoNamespacedGeneratingPolicy},
+		{kyvernoPolicyAPIVersion, kyvernoNamespacedImageValidatingPolicy},
 	}
 
-	expected := []map[string]interface{}{
-		{
-			"objectDefinition": map[string]interface{}{
-				"apiVersion": configPolicyAPIVersion,
-				"kind":       configPolicyKind,
-				"metadata":   map[string]interface{}{"name": "inform-kyverno-my-awesome-policy"},
-				"spec": map[string]interface{}{
-					"namespaceSelector": map[string]interface{}{
-						"exclude": []string{"kube-*"},
-						"include": []string{"*"},
+	for _, test := range tests {
+		t.Run(
+			"kind="+test.kind,
+			func(t *testing.T) {
+				t.Parallel()
+
+				manifest := map[string]interface{}{
+					"apiVersion": test.apiVersion,
+					"kind":       test.kind,
+					"metadata": map[string]interface{}{
+						"name": "my-awesome-policy",
 					},
-					"remediationAction": "inform",
-					"severity":          "medium",
-					"object-templates": []map[string]interface{}{
-						{
-							"complianceType": "mustnothave",
-							"objectDefinition": map[string]interface{}{
-								"apiVersion": kyvernoPolicyReportAPIVersion,
-								"kind":       "ClusterPolicyReport",
-								"results": []map[string]interface{}{
+				}
+
+				expected := []map[string]interface{}{
+					{
+						"objectDefinition": map[string]interface{}{
+							"apiVersion": configPolicyAPIVersion,
+							"kind":       configPolicyKind,
+							"metadata":   map[string]interface{}{"name": "inform-kyverno-my-awesome-policy"},
+							"spec": map[string]interface{}{
+								"namespaceSelector": map[string]interface{}{
+									"exclude": []string{"kube-*"},
+									"include": []string{"*"},
+								},
+								"remediationAction": "inform",
+								"severity":          "medium",
+								"object-templates": []map[string]interface{}{
 									{
-										"policy": "my-awesome-policy",
-										"result": "fail",
+										"complianceType": "mustnothave",
+										"objectDefinition": map[string]interface{}{
+											"apiVersion": kyvernoPolicyReportAPIVersion,
+											"kind":       clusterPolicyReportKind,
+											"results": []map[string]interface{}{
+												{
+													"policy": "my-awesome-policy",
+													"result": "fail",
+												},
+											},
+										},
+									},
+									{
+										"complianceType": "mustnothave",
+										"objectDefinition": map[string]interface{}{
+											"apiVersion": kyvernoPolicyReportAPIVersion,
+											"kind":       namespacedPolicyReportKind,
+											"results": []map[string]interface{}{
+												{
+													"policy": "my-awesome-policy",
+													"result": "fail",
+												},
+											},
+										},
 									},
 								},
 							},
 						},
-						{
-							"complianceType": "mustnothave",
-							"objectDefinition": map[string]interface{}{
-								"apiVersion": kyvernoPolicyReportAPIVersion,
-								"kind":       "PolicyReport",
-								"results": []map[string]interface{}{
-									{
-										"policy": "my-awesome-policy",
-										"result": "fail",
-									},
-								},
-							},
-						},
 					},
-				},
+				}
+				templates := k.Expand(manifest, "medium")
+
+				assertReflectEqual(t, templates, expected)
 			},
-		},
+		)
 	}
-
-	templates := k.Expand(manifest, "medium")
-
-	assertReflectEqual(t, templates, expected)
 }


### PR DESCRIPTION
Support policy generator expansion for the validating, mutating, generating, and image validation policy types in policies.kyverno.io/v1

ref: https://issues.redhat.com/browse/ACM-30858