### PR TITLE
fix: add `annotations` to generator struct

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -42,18 +42,17 @@ const (
 // Plugin is used to store the PolicyGenerator configuration and the methods to generate the
 // desired policies.
 type Plugin struct {
-	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
-	Kind       string `json:"kind,omitempty"       yaml:"kind,omitempty"`
-	Metadata   struct {
-		Name string `json:"name,omitempty" yaml:"name,omitempty"`
-	} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	PlacementBindingDefaults struct {
-		Name string `json:"name,omitempty" yaml:"name,omitempty"`
-	} `json:"placementBindingDefaults,omitempty" yaml:"placementBindingDefaults,omitempty"`
-	PolicyDefaults    types.PolicyDefaults    `json:"policyDefaults,omitempty"    yaml:"policyDefaults,omitempty"`
-	PolicySetDefaults types.PolicySetDefaults `json:"policySetDefaults,omitempty" yaml:"policySetDefaults,omitempty"`
-	Policies          []types.PolicyConfig    `json:"policies"                    yaml:"policies"`
-	PolicySets        []types.PolicySetConfig `json:"policySets"                  yaml:"policySets"`
+	APIVersion string         `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind       string         `json:"kind,omitempty"       yaml:"kind,omitempty"`
+	Metadata   types.Metadata `json:"metadata"             yaml:"metadata"`
+
+	//nolint:lll
+	PlacementBindingDefaults types.PlacementBindingDefaults `json:"placementBindingDefaults" yaml:"placementBindingDefaults"`
+	PolicyDefaults           types.PolicyDefaults           `json:"policyDefaults"           yaml:"policyDefaults"`
+	PolicySetDefaults        types.PolicySetDefaults        `json:"policySetDefaults"        yaml:"policySetDefaults"`
+	Policies                 []types.PolicyConfig           `json:"policies"                 yaml:"policies"`
+	PolicySets               []types.PolicySetConfig        `json:"policySets"               yaml:"policySets"`
+
 	// A set of all placement names that have been processed or generated
 	allPlcs map[string]bool
 	// The base of the directory tree to restrict all manifest files to be within

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -160,3 +160,12 @@ type PolicyDependency struct {
 	Name       string `json:"name"                 yaml:"name"`
 	Namespace  string `json:"namespace,omitempty"  yaml:"namespace,omitempty"`
 }
+
+type PlacementBindingDefaults struct {
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type Metadata struct {
+	Name        string            `json:"name,omitempty"        yaml:"name,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}


### PR DESCRIPTION
Kustomize uses `internal.config.kubernetes.io` annotations when manifests are in flight. They started adding them to Helm manifests, so they need to be added to our struct to tolerate them.

ref: https://redhat.atlassian.net/browse/ACM-32044

Slack thread: https://redhat-internal.slack.com/archives/CU4QXLPQB/p1774561419369229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal configuration handling with stronger, more consistent type definitions to improve code reliability and maintainability. These internal improvements enhance system stability without changing any user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->